### PR TITLE
[TRIVIAL] modify the bib for BenchCLAMP

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ following papers:
         doi = {10.48550/ARXIV.2206.10668},
         url = {https://arxiv.org/abs/2206.10668},
         author = {Roy, Subhro and Thomson, Sam and Chen, Tongfei and Shin, Richard and Pauls, Adam and Eisner, Jason and Van Durme, Benjamin},
-        title = {BenchCLAMP: A Benchmark for Evaluating Language Models on Semantic Parsing},
+        title = {{BenchCLAMP}: A Benchmark for Evaluating Language Models on Semantic Parsing},
         publisher = {arXiv},
         year = {2022},
     }


### PR DESCRIPTION
very minor -- the old bib would render `BenchCLAMP` as `Benchclamp`.